### PR TITLE
added support for `nanbox deploy dry-run`

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -1,2 +1,5 @@
 run.config:
   engine: nodejs
+
+web.app:
+  start: "npm run dev --host 0.0.0.0"


### PR DESCRIPTION
Added a web.app component that spins up the vue dev server in a "production" environment in an attempt to cover the first bullet point in #1 